### PR TITLE
Update macos.yml with proper cmake macos build folder

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,4 +18,4 @@ jobs:
     - name: dependencies
       run: brew install pkgconfig libxml2 glibmm libxml++ jack liblo libsndfile gtkmm3 eigen boost gsl fftw
     - name: make
-      run: mkdir macos && cd macos && cmake ../ && make
+      run: mkdir macos && cd macos && cmake -B . -S ../ && make


### PR DESCRIPTION
changed cmake step to cmake -B. -S../ so to keep proper separate folder for osx build targets