### PR TITLE
Use BREWPREFIX in rules.mk to support different installation location on macOS

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -38,8 +38,7 @@ ifeq ($(UNAME_S),Linux)
   BINFILES += tascar_hdspmixer
 endif
 ifeq ($(UNAME_S),Darwin)
-#BREWPREFIX := $(shell brew --prefix)
-BREWPREFIX = /opt/homebrew
+BREWPREFIX := $(shell brew --prefix)
 LIBTASCARDLL=../libtascar/$(BUILD_DIR)/libtascar.dylib
 CXXFLAGS += -I$(BREWPREFIX)/include -DISMACOS
 CPPFLAGS += -I$(BREWPREFIX)/include

--- a/rules.mk
+++ b/rules.mk
@@ -41,13 +41,13 @@ ifeq ($(UNAME_S),Darwin)
 #BREWPREFIX := $(shell brew --prefix)
 BREWPREFIX = /opt/homebrew
 LIBTASCARDLL=../libtascar/$(BUILD_DIR)/libtascar.dylib
-CXXFLAGS += -I/opt/homebrew/include -DISMACOS
-CPPFLAGS += -I/opt/homebrew/include
-LDFLAGS += -L/opt/homebrew/lib
-LSLFLAGSFIND := $(addprefix -I,$(dir $(shell find /opt/homebrew/ -name lsl_cpp.h)))
+CXXFLAGS += -I$(BREWPREFIX)/include -DISMACOS
+CPPFLAGS += -I$(BREWPREFIX)/include
+LDFLAGS += -L$(BREWPREFIX)/lib
+LSLFLAGSFIND := $(addprefix -I,$(dir $(shell find $(BREWPREFIX)/ -name lsl_cpp.h)))
 CXXFLAGS += $(LSLFLAGSFIND)
-#  LDFLAGS += -F/opt/homebrew/Cellar/lsl/1.17.4/Frameworks -framework lsl
-#  $(addprefix -I,$(dir $(shell find /opt/homebrew/ -name lsl_cpp.h)))
+#  LDFLAGS += -F$(BREWPREFIX)/Cellar/lsl/1.17.4/Frameworks -framework lsl
+#  $(addprefix -I,$(dir $(shell find $(BREWPREFIX)/ -name lsl_cpp.h)))
 # -framework Lsl
 LSLCFLAGS = -I$(BREWPREFIX)/Frameworks/lsl.framework/Headers
 LSLLIBS = -F$(BREWPREFIX)/Frameworks/ -framework lsl


### PR DESCRIPTION
# Rationale

I have multiple copies of homebrew installed and so my main `brew` is not in its default prefix. The current `rules.mk` defines BREWPREFIX but doesn't use it, so compiling in this situation doesn't work out of the box.

There's a line setting BREWPREFIX to the output of `brew --prefix`, but it's commented out. On my machine this seems to work so I'm not sure what the reasoning for commenting it out was, but if there are problems I'm okay with reverting it to the default prefix since I can override it with `make BREWPREFIX=$(brew --prefix)` myself so long as the variable is used.

The tap still won't work on non-default prefixes because the post-install and tascar.app wrapper script also hardcode the brew prefix, but this makes it possible to compile and use the tascar binary directly using e.g. `make PREFIX="$HOME/.local" install`.

Another runtime caveat is that checks for tascar libs won't resolve unless in the default prefix, but TASCAR seems to check for `HOMEBREW_PREFIX` so it is possible to somewhat work around this by setting that to the install directory.

I think solving the problem more cleanly would probably require some more thinking and maybe some refactoring, but this gets TASCAR slightly more compatible.